### PR TITLE
fix: make gradio optional dep to resolve typer version conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
     "safetensors==0.5.3",
     "spacy-pkuseg",
     "pykakasi==2.3.0",
-    "gradio==6.8.0",
     "russian-text-stresser @ git+https://github.com/Vuizur/add-stress-to-epub",
     "auto-editor>=27.0.0",
     "pyloudnorm",
@@ -44,6 +43,11 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[project.optional-dependencies]
+demo = [
+    "gradio==6.8.0",
+]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- Move `gradio==6.8.0` from `[project.dependencies]` to `[project.optional-dependencies].demo`

## Why
`gradio==6.8.0` requires `typer>=0.12,<1.0`, but `russian-text-stresser` → `spacy==3.6.*` requires `typer<0.10.0`. This causes `uv lock` to fail with unsatisfiable dependencies.

Gradio is only used in root-level demo scripts, not in `src/chatterbox/`. Making it optional unblocks `chatterbox-api`.

## Acceptance criteria
- [ ] `uv lock --upgrade` in chatterbox-api succeeds
- [ ] Core TTS import works: `from chatterbox.tts import ChatterboxTTS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)